### PR TITLE
Fix bug issue#2 - disabled check permissions

### DIFF
--- a/iblock_tools.php
+++ b/iblock_tools.php
@@ -97,6 +97,7 @@ class CIBlockTools
             array('ID' => 'ASC'),
             array(
                 'ACTIVE' => 'Y',
+                'CHECK_PERMISSIONS' => 'N'
             )
         );
         while($arr = $db->Fetch()){


### PR DESCRIPTION
Исправлен баг описанный здесь - https://github.com/xescoder/bitrix-iblock-tools/issues/2. Выключена проверка прав при выборке списка ИБ.
